### PR TITLE
Urgent fix to force the python address list submitter example code

### DIFF
--- a/als/index.html
+++ b/als/index.html
@@ -67,7 +67,7 @@ files = None
 
 m = re.search('^(http|ftp)s?://', filename)
 if m:
-	fields['inputDataUrl'] = filename
+	files = {'inputDataUrl': ('', filename)}
 else:
 	files = {'inputData': open(filename,'rb')}
 


### PR DESCRIPTION
to always use multi-part form encoding when submitting jobs to CPF.